### PR TITLE
fix: there can be no spaces between scope and registry

### DIFF
--- a/src/webui/utils/cli-utils.js
+++ b/src/webui/utils/cli-utils.js
@@ -21,7 +21,7 @@ export const copyToClipBoardUtility = (str: string) => (event: SyntheticEvent<HT
 };
 
 export function getCLISetConfigRegistry(command: string, scope: string, registryUrl: string): string {
-  return `${command} ${scope} registry ${registryUrl}`;
+  return `${command} ${scope}registry ${registryUrl}`;
 }
 
 export function getCLISetRegistry(command: string, registryUrl: string): string {


### PR DESCRIPTION
**Type: Chore**
