### PR TITLE
test: fix formatDateDistance test

### DIFF
--- a/test/unit/utils/package.spec.js
+++ b/test/unit/utils/package.spec.js
@@ -52,13 +52,21 @@ describe('formatDate', () => {
 
 describe('formatDateDistance', () => {
   test('should calculate the distance', () => {
+    const dateAboutTwoMonthsAgo = () => {
+      const date = new Date();
+      date.setMonth(date.getMonth() - 1);
+      date.setDate(date.getDay() - 20);
+      return date;
+    };
     const dateTwoMonthsAgo = () => {
       const date = new Date();
       date.setMonth(date.getMonth() - 2);
       return date;
     };
-    const date = dateTwoMonthsAgo();
-    expect(formatDateDistance(date)).toEqual('about 2 months');
+    const date1 = dateAboutTwoMonthsAgo();
+    const date2 = dateTwoMonthsAgo();
+    expect(formatDateDistance(date1)).toEqual('about 2 months');
+    expect(formatDateDistance(date2)).toEqual('2 months');
   });
 });
 


### PR DESCRIPTION
Test formatDateDistance with a date which is about 2 months in the past and another which is exactly 2 months in the past.

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
unit tests

The following has been addressed in the PR:

*

**Description:**

The `formatDateDistance` test was using a date which was exactly 2 months ago so `about 2 months` is not correct but `2 months`. I have added another case where this is `about 2 months` as expected to cover both cases.

