### PR TITLE
chore: add missing __UI_OPTIONS

### DIFF
--- a/tools/webpack.dev.config.babel.js
+++ b/tools/webpack.dev.config.babel.js
@@ -34,6 +34,7 @@ export default {
       __APP_VERSION__: `"${getPackageJson('version')}"`,
     }),
     new HTMLWebpackPlugin({
+      __UI_OPTIONS: JSON.stringify({base: '/'}),
       title: 'Verdaccio Dev UI',
       scope: '',
       logo: 'https://verdaccio.org/img/logo/symbol/svg/verdaccio-tiny.svg',


### PR DESCRIPTION
**Type:**

dev stack

**Description:**

this object `__UI_OPTIONS` will replace the other variables, it is easier to scale adding new properties.
I'll extend the info in a future document about plugins.

Due to this object was missing, the `yarn dev:web` was broken. 


