### PR TITLE
chore: validator use less bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ __tests__
 # Compiled script
 static/*
 coverage/
-
+stats.json

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "verdaccio-memory": "2.0.0",
     "webpack": "4.20.2",
     "webpack-bundle-analyzer": "3.0.4",
+    "webpack-bundle-size-analyzer": "3.0.0",
     "webpack-cli": "3.2.3",
     "webpack-dev-server": "3.2.1",
     "webpack-merge": "4.2.1",
@@ -121,6 +122,8 @@
     "dev:web": "cross-env BABEL_ENV=ui babel-node tools/dev.server.js",
     "verdaccio:server": "node tools/verdaccio.js",
     "build": "npm run pre:webpack && cross-env BABEL_ENV=ui webpack --config tools/webpack.prod.config.babel.js",
+    "build:stats": "cross-env BABEL_ENV=ui webpack --config tools/webpack.prod.config.babel.js --json > stats.json",
+    "build:size": "cross-env BABEL_ENV=ui webpack --config tools/webpack.prod.config.babel.js --json | webpack-bundle-size-analyzer",
     "dev": "concurrently --kill-others \"npm run dev:web\" \"npm run verdaccio:server\""
   },
   "engines": {

--- a/src/webui/utils/url.js
+++ b/src/webui/utils/url.js
@@ -1,14 +1,15 @@
-import validator from 'validator';
+import isURLValidator from 'validator/lib/isURL';
+import isEmailValidator from 'validator/lib/isEmail';
 
 export function isURL(url) {
-  return validator.isURL(url || '', {
+  return isURLValidator(url || '', {
     protocols: ['http', 'https', 'git+https'],
     require_protocol: true,
   });
 }
 
 export function isEmail(email) {
-  return validator.isEmail(email || '');
+  return isEmailValidator(email || '');
 }
 
 export function getRegistryURL() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6519,6 +6519,11 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+humanize@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.verdaccio.org/humanize/-/humanize-0.0.9.tgz#1994ffaecdfe9c441ed2bdac7452b7bb4c9e41a4"
+  integrity sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=
+
 husky@0.15.0-rc.8:
   version "0.15.0-rc.8"
   resolved "https://registry.npmjs.org/husky/-/husky-0.15.0-rc.8.tgz#b658c597a8f9bbcd00a5c039709e7c61e61238e7"
@@ -13390,6 +13395,15 @@ webpack-bundle-analyzer@3.0.4:
     mkdirp "^0.5.1"
     opener "^1.5.1"
     ws "^6.0.0"
+
+webpack-bundle-size-analyzer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.verdaccio.org/webpack-bundle-size-analyzer/-/webpack-bundle-size-analyzer-3.0.0.tgz#c0657e9787cf644a0b91d891ae15553ba61bbc71"
+  integrity sha512-GfQ/Mch1o2MGonGPIMawwlxXOmYp/F8EXiT9txDO6qASo7G5hODngWMNW1KkJxeYRvgMUuPgbSsmdsXEsBNEeg==
+  dependencies:
+    commander "^2.19.0"
+    filesize "^3.6.1"
+    humanize "0.0.9"
 
 webpack-cli@3.2.3:
   version "3.2.3"


### PR DESCRIPTION
**Type:** fix

**Description:**

Includes validator utilities by accessing the feature to avoid include the whole library and reduces the bundle size.

It adds two new scripts for bundle analysis to prove my theory.

You can use http://webpack.github.io/analyse/ for analysis of the `stats.json`

```
➜ yarn build:size 
➜ yarn build:stats 
```


```
➜ yarn build:size 
yarn run v1.16.0
$ cross-env BABEL_ENV=ui webpack --config tools/webpack.prod.config.babel.js --json | webpack-bundle-size-analyzer
@material-ui/core: 610.17 KB (30.6%)
  hoist-non-react-statics: 2.82 KB (0.462%)
  <self>: 607.35 KB (99.5%)
core-js: 222.97 KB (11.2%)
react-dom: 106.84 KB (5.35%)
popper.js: 86 KB (4.31%)
jss: 77.52 KB (3.88%)
  warning: 1.76 KB (2.28%)
  <self>: 75.75 KB (97.7%)
date-fns: 53.21 KB (2.66%)
lodash: 43.35 KB (2.17%)
react-autowhatever: 33.64 KB (1.68%)
create-emotion: 31.76 KB (1.59%)
history: 31.26 KB (1.57%)
react-transition-group: 30.6 KB (1.53%)
react-autosuggest: 29.58 KB (1.48%)
cssfilter: 25.38 KB (1.27%)
babel-polyfill: 24.67 KB (1.24%)
  regenerator-runtime: 23.86 KB (96.7%)
  <self>: 833 B (3.30%)
regenerator-runtime: 23.51 KB (1.18%)
react-router: 23.12 KB (1.16%)
react-router-dom: 22.44 KB (1.12%)
xss: 21.9 KB (1.10%)
validator: 14.17 KB (0.709%)
github-markdown-css: 13.1 KB (0.656%)
style-loader: 13.1 KB (0.656%)
whatwg-fetch: 12.95 KB (0.649%)
react-emotion: 11.19 KB (0.561%)
path-to-regexp: 10.67 KB (0.534%)
  isarray: 120 B (1.10%)
  <self>: 10.56 KB (98.9%)
dom-helpers: 9.93 KB (0.497%)
diacritic: 9.91 KB (0.496%)
@babel/runtime: 9.21 KB (0.461%)
@material-ui/icons: 8.27 KB (0.414%)
js-base64: 8.09 KB (0.405%)
react: 6.86 KB (0.343%)
css-loader/index.js?module&sourceMap=false&localIdentName=[path][name]__[local]--[hash:base64:5]
        !/Users/xxxx/projects/@verdaccio/ui: 6.68 KB (0.335%)
  resolve-url-loader/index.js?keepQuery!/Users/xxxx/projects/@verdaccio/ui: 6.68 KB (100%)
    sass-loader: 6.68 KB (100%)
    <self>: 0 B (0.00%)
  <self>: 0 B (0.00%)
css-vendor: 6.4 KB (0.320%)
normalize.css: 6.03 KB (0.302%)
react-lifecycles-compat: 5.91 KB (0.296%)
@material-ui/utils: 5.54 KB (0.278%)
jss-default-unit: 5.53 KB (0.277%)
jss-nested: 5.2 KB (0.261%)
  warning: 1.76 KB (33.9%)
  <self>: 3.44 KB (66.1%)
react-event-listener: 5.19 KB (0.260%)
scheduler: 5.08 KB (0.254%)
jss-global: 4.82 KB (0.241%)
recompose: 4.06 KB (0.203%)
keycode: 3.63 KB (0.182%)
deepmerge: 3.05 KB (0.153%)
normalize-scroll-left: 2.86 KB (0.143%)
section-iterator: 2.82 KB (0.141%)
react-themeable: 2.82 KB (0.141%)
  object-assign: 817 B (28.3%)
  <self>: 2.02 KB (71.7%)
css-loader: 2.64 KB (0.132%)
prop-types: 2.58 KB (0.129%)
react-is: 2.48 KB (0.124%)
autosuggest-highlight: 2.3 KB (0.115%)
object-assign: 2.06 KB (0.103%)
hoist-non-react-statics: 2.02 KB (0.101%)
debounce: 1.8 KB (0.0901%)
typeface-roboto: 1.79 KB (0.0898%)
localstorage-memory: 1.78 KB (0.0892%)
warning: 1.73 KB (0.0867%)
jss-camel-case: 1.66 KB (0.0829%)
jss-vendor-prefixer: 1.59 KB (0.0798%)
fbjs: 1.58 KB (0.0790%)
webpack: 1.56 KB (0.0783%)
react-hot-loader: 1.43 KB (0.0717%)
invariant: 1.36 KB (0.0683%)
classnames: 1.17 KB (0.0586%)
stylis-rule-sheet: 1.1 KB (0.0553%)
brcast: 1011 B (0.0494%)
is-plain-object: 856 B (0.0419%)
symbol-observable: 736 B (0.0360%)
emotion: 641 B (0.0313%)
jss-props-sort: 566 B (0.0277%)
is-in-browser: 510 B (0.0249%)
hyphenate-style-name: 452 B (0.0221%)
tiny-warning: 361 B (0.0177%)
shallow-equal: 343 B (0.0168%)
isobject: 288 B (0.0141%)
@emotion/memoize: 178 B (0.00871%)
<self>: 257.38 KB (12.9%)
```

