### PR TITLE
fix: fixed failed to load all packages after login

### DIFF
--- a/src/webui/app.js
+++ b/src/webui/app.js
@@ -120,9 +120,9 @@ export default class App extends Component {
     const { username, token, error } = await makeLogin(usernameValue, passwordValue);
 
     if (username && token) {
-      this.setLoggedUser(username, token);
       storage.setItem('username', username);
       storage.setItem('token', token);
+      this.setLoggedUser(username, token);
     }
 
     if (error) {


### PR DESCRIPTION
**fix:**

Non-public packages not included in the package-list after login.

**Description:**

A login forces react to reload the list of available packages (by changing the state).
However the state (which triggers react to refresh) is set before storing the login token resulting in fetching (XHR GET) only the public packages as the token is not yet available in the GET request.

Fixed by setting the storage items ('username' and 'token') before this.setLoggedUser().

Resolves #72 
