### PR TITLE
fix: @typescript-eslint/no-explicit-any

### DIFF
--- a/src/components/Dependencies/Dependencies.tsx
+++ b/src/components/Dependencies/Dependencies.tsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment, ReactElement } from 'react';
-import { withRouter, RouteProps } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 import CardContent from '@material-ui/core/CardContent';
 
 import { DetailContextConsumer, VersionPageConsumerProps } from '../../pages/version/Version';
@@ -7,18 +7,18 @@ import { DetailContextConsumer, VersionPageConsumerProps } from '../../pages/ver
 import { CardWrap, Heading, Tags, Tag } from './styles';
 import NoItems from '../NoItems';
 
-interface DepDetailProps {
+type DepDetailProps = {
   name: string;
   version: string;
-  onLoading: () => void;
-  history: string[];
-}
+  onLoading?: () => void;
+} & RouteComponentProps;
+
 interface DepDetailState {
   name: string;
   version: string;
 }
 
-class DepDetail extends Component<DepDetailProps & RouteProps, DepDetailState> {
+class DepDetail extends Component<DepDetailProps, DepDetailState> {
   constructor(props: DepDetailProps) {
     super(props);
     const { name, version } = this.props;
@@ -39,12 +39,12 @@ class DepDetail extends Component<DepDetailProps & RouteProps, DepDetailState> {
     const { name } = this.state;
     const { onLoading, history } = this.props;
 
-    onLoading();
+    onLoading && onLoading();
     history.push(`/-/web/detail/${name}`);
   };
 }
 
-const WrapperDependencyDetail = withRouter<any>(DepDetail);
+const WrapperDependencyDetail = withRouter(DepDetail);
 
 class DependencyBlock extends Component<{ title: string; dependencies: [] }> {
   public render(): ReactElement<HTMLElement> {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** Refactor typescript warnings

The following has been addressed in the PR:

*  There is a related issue - #74 
*  Unit or Functional tests are included in the PR

**Description:**
Following on from #77, this PR resolves the `@typescript-eslint/no-explicit-any` rule on withRouter().

**Resolves:** #74 
<!-- Resolves #??? -->
