### PR TITLE
fix(api): correctly handle responses with missing content-type header

### DIFF
--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -11,6 +11,22 @@ describe('api', () => {
   };
 
   describe('handleResponseType', () => {
+    test('should handle missing Content-Type', async () => {
+      const response: Response = {
+        url: 'http://localhost:8080/-/packages',
+        ok: false,
+        // @ts-ignore
+        headers: {
+          get: () => null,
+        } as Headers,
+      } as Response;
+
+      const handled = await handleResponseType(response);
+
+      // Should this actually return [false, null] ?
+      expect(handled).toBeUndefined();
+    });
+
     test('should test tgz scenario', async () => {
       const blob = new Blob(['foo']);
       const blobPromise = Promise.resolve<Blob>(blob);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -8,20 +8,20 @@ import '../../types';
  */
 export function handleResponseType(response: Response): Promise<[boolean, Blob | string]> | Promise<void> {
   if (response.headers) {
-    const contentType = response.headers.get('Content-Type') as string;
-    if (contentType.includes('application/pdf')) {
+    const contentType = response.headers.get('Content-Type');
+    if (contentType && contentType.includes('application/pdf')) {
       return Promise.all([response.ok, response.blob()]);
     }
-    if (contentType.includes('application/json')) {
+    if (contentType && contentType.includes('application/json')) {
       return Promise.all([response.ok, response.json()]);
     }
     // it includes all text types
-    if (contentType.includes('text/')) {
+    if (contentType && contentType.includes('text/')) {
       return Promise.all([response.ok, response.text()]);
     }
 
     // unfortunatelly on download files there is no header available
-    if (response.url && response.url.endsWith('.tgz') !== null) {
+    if (response.url && response.url.endsWith('.tgz') === true) {
       return Promise.all([response.ok, response.blob()]);
     }
   }


### PR DESCRIPTION
Also prevents non .tgz requests from being handled as tgz requests — the previous if condition was incorrect

**Type:** bug

The following has been addressed in the PR:

*  There is a related issue? No
*  Unit or Functional tests are included in the PR? Yes

**Description:**

Previously if for whatever reason an API request resulted in a 400 error without a content-type header, then this code would fail, as it was trying to call `includes` on `null`, resulting in what looked like a [plugin/configuration error](https://github.com/bufferoverflow/verdaccio-gitlab/issues/82). Additionally, I noticed in testing that the check for handling `.tgz` files was incorrect, and it should've been `request.url.includes('.tgz') === true` rather than `!== null`, though I'm not sure the best way to test that.
