### PR TITLE
fix(ui):  fix the hover effect on the packageItem's author area

### DIFF
--- a/src/components/Package/Package.tsx
+++ b/src/components/Package/Package.tsx
@@ -20,7 +20,6 @@ import {
   IconButton,
   OverviewItem,
   PackageList,
-  PackageListItem,
   PackageListItemText,
   PackageTitle,
   Published,
@@ -174,13 +173,13 @@ const Package: React.FC<PackageInterface> = ({
   return (
     <PackageList className={'package'}>
       <ListItem alignItems={'flex-start'}>{renderPackageListItemText()}</ListItem>
-      <PackageListItem alignItems={'flex-start'} button={true}>
+      <ListItem alignItems={'flex-start'}>
         {renderAuthorInfo()}
         {renderVersionInfo()}
         {renderPublishedInfo()}
         {renderFileSize()}
         {renderLicenseInfo()}
-      </PackageListItem>
+      </ListItem>
     </PackageList>
   );
 };

--- a/src/components/Package/styles.ts
+++ b/src/components/Package/styles.ts
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import MuiIconButton from '@material-ui/core/IconButton';
 import Photo from '@material-ui/core/Avatar';
@@ -120,6 +119,10 @@ export const PackageList = styled(List)({
     '&:hover': {
       backgroundColor: colors.greyLight3,
     },
+
+    '> :last-child': {
+      paddingTop: 0,
+    },
   },
 });
 
@@ -143,12 +146,6 @@ export const TagContainer = styled('span')`
     }
   }
 `;
-
-export const PackageListItem = styled(ListItem)({
-  '&&': {
-    paddingTop: 0,
-  },
-});
 
 export const PackageListItemText = styled(ListItemText)({
   '&&': {


### PR DESCRIPTION
__Type:__
bug

__Description:__
This should fix unwanted hover in PackageItem's author section.

__Notes:__
The issue here is that `PackageListItem` has the prop button as `true`, but if I removed that or set to 'false' type-script complains that the button prop should be always set to `true`.
I don't have many experiences with the type-script, but I suppose that this issue is from the `material-ui` types.

I came to with workaround but maybe there will be exist something better.

close #135