### PR TITLE
fix: cli command

### DIFF
--- a/src/components/Help/Help.tsx
+++ b/src/components/Help/Help.tsx
@@ -30,7 +30,7 @@ const Help: React.FC = () => {
         <HelpTitle color="textSecondary" gutterBottom={true}>
           {'To publish your first package just:'}
         </HelpTitle>
-        {renderHeadingClipboardSegments('1. Login', `npm adduser --registry ${registryUrl}`)}
+        {renderHeadingClipboardSegments('1. Login', `npm adduser --registry ${registryUrl} --always-auth`)}
         {renderHeadingClipboardSegments('2. Publish', `npm publish --registry ${registryUrl}`)}
         <Typography variant="body2">{'3. Refresh this page.'}</Typography>
       </CardContent>

--- a/src/utils/cli-utils.ts
+++ b/src/utils/cli-utils.ts
@@ -23,7 +23,7 @@ export function getCLISetConfigRegistry(command: string, scope: string, registry
 }
 
 export function getCLISetRegistry(command: string, registryUrl: string): string {
-  return `${command} --registry ${registryUrl}`;
+  return `${command} --registry ${registryUrl} --always-auth`;
 }
 
 export function getCLIChangePassword(command: string, registryUrl: string): string {


### PR DESCRIPTION
**Type:**

The following has been addressed in the PR:

*  There is a related issue: https://github.com/verdaccio/verdaccio/issues/1481#issuecomment-536233237
*  Unit or Functional tests are included in the PR: nop

**Description:**

When JWT is used, `--always-auth` should always be used, as stated in [npm `cli` documentation](https://docs.npmjs.com/cli/adduser#always-auth):

> ### always-auth
> 
> Default: false
> 
> If specified, save configuration indicating that all requests to the given 
> registry should include authorization information. Useful for private
> registries. Can be used with `--registry` and / or `--scope`, e.g.
> 
>     npm adduser --registry=http://private-registry.example.com --always-auth

> This will ensure that all requests to that registry (including for tarballs)
> include an authorization header. This setting may be necessary for use with
> private registries where metadata and package tarballs are stored on hosts with
> different hostnames. See `always-auth` in `npm-config(7)` for more details on
> always-auth. Registry-specific configuration of `always-auth` takes precedence
> over any global configuration.

Better always showing it even with legacy security than not showing it, this is displayed to all my users as a **helper** and can conduct to time lost for many of them.