### PR TITLE
fix: warning about modules with names differing in casing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,7 @@ renderApp(App);
 // @ts-ignore
 if (module.hot) {
   // @ts-ignore
-  module.hot.accept('./app', () => {
+  module.hot.accept('./App', () => {
     renderApp(App);
   });
 }


### PR DESCRIPTION
**Type:**

_The following has been addressed in the PR:_

This PR removes a warning in the dev environment.

**Description:**

The `module.accept` method was called with a different casing with resulted in a warning in the console :)

![image](https://user-images.githubusercontent.com/6087868/66043412-5a1b5b80-e51f-11e9-9ceb-2561d8e1dbda.png)

