### PR TITLE
chore: readded null check

### DIFF
--- a/src/utils/login.test.ts
+++ b/src/utils/login.test.ts
@@ -15,6 +15,10 @@ jest.mock('./api', () => ({
 }));
 
 describe('isTokenExpire', (): void => {
+  test('isTokenExpire - null is not a valid payload', (): void => {
+    expect(isTokenExpire(null)).toBeTruthy();
+  });
+
   test('isTokenExpire - token is not a valid payload', (): void => {
     expect(isTokenExpire('not_a_valid_token')).toBeTruthy();
   });


### PR DESCRIPTION
This PR re-adds an explicit `null` test for `isTokenExpire` which got lost in https://github.com/verdaccio/ui/pull/157.