### PR TITLE
Fix: Fixed imports - Icon Button

### DIFF
--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -1,8 +1,9 @@
 import React, { MouseEvent } from 'react';
-import IconButton from '@material-ui/core/IconButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import AccountCircle from '@material-ui/icons/AccountCircle';
+
+import IconButton from '../../muiComponents/IconButton';
 
 import HeaderGreetings from './HeaderGreetings';
 

--- a/src/components/Header/HeaderToolTipIcon.tsx
+++ b/src/components/Header/HeaderToolTipIcon.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import IconButton from '@material-ui/core/IconButton';
 import Info from '@material-ui/icons/Info';
 import Help from '@material-ui/icons/Help';
 import Search from '@material-ui/icons/Search';
+
+import IconButton from '../../muiComponents/IconButton';
 
 import { IconSearchButton, StyledExternalLink } from './styles';
 


### PR DESCRIPTION
**Type:** Fix

**The following has been addressed in the PR:** There is no issue for this PR

**Description:**

Fixed Icon Button imports. Every mui components used should be imported from the muiComponents folder.
