### PR TITLE
chore(deps): remove types from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/lodash": "4.14.141",
     "@types/node": "12.7.8",
     "@types/react": "16.9.2",
+    "@types/react-autosuggest": "9.3.11",
     "@types/react-dom": "16.9.0",
     "@types/react-router-dom": "5.1.0",
     "@types/request": "2.48.3",
@@ -213,8 +214,5 @@
     "type": "opencollective",
     "url": "https://opencollective.com/verdaccio",
     "logo": "https://opencollective.com/verdaccio/logo.txt"
-  },
-  "dependencies": {
-    "@types/react-autosuggest": "9.3.11"
   }
 }


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** chore

The following has been addressed in the PR:

*  There is a related issue? No
*  Unit or Functional tests are included in the PR No

**Description:** @types/react-autosuggest was defined as dependency instead of be in devDependency list

<!-- Resolves #??? -->
