### PR TITLE
Improved Typings for API class

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -139,7 +139,6 @@ export class Search extends Component<RouteComponentProps<{}>, State> {
    */
   private handleFetchPackages: handleFetchPackages = async ({ value }) => {
     try {
-      // @ts-ignore
       const controller = new window.AbortController();
       const signal = controller.signal;
       // Keep track of search requests.

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -3,22 +3,12 @@
 import { handleResponseType } from '../../src/utils/api';
 
 describe('api', () => {
-  // no the best mock, but I'd look for a mock library to work with fetch in the future
-  // @ts-ignore
-  const headers: Headers = {
-    // @ts-ignore
-    get: () => [],
-  };
-
   describe('handleResponseType', () => {
     test('should handle missing Content-Type', async () => {
       const response: Response = {
         url: 'http://localhost:8080/-/packages',
         ok: false,
-        // @ts-ignore
-        headers: {
-          get: () => null,
-        } as Headers,
+        headers: new Headers(),
       } as Response;
 
       const handled = await handleResponseType(response);
@@ -34,7 +24,7 @@ describe('api', () => {
         url: 'http://localhost:8080/bootstrap/-/bootstrap-4.3.1.tgz',
         blob: () => blobPromise,
         ok: true,
-        headers,
+        headers: new Headers(),
       } as Response;
       const handled = await handleResponseType(response);
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,7 +6,7 @@ import '../../types';
  * @param {object} response
  * @returns {promise}
  */
-export function handleResponseType(response: Response): Promise<[boolean, Blob | string]> | Promise<void> {
+export function handleResponseType(response: Response): Promise<[boolean, Blob | string] | void> {
   if (response.headers) {
     const contentType = response.headers.get('Content-Type');
     if (contentType && contentType.includes('application/pdf')) {
@@ -52,7 +52,6 @@ class API {
         credentials: 'same-origin',
         ...options,
       })
-        // @ts-ignore
         .then(handleResponseType)
         .then(response => {
           if (response[0]) {

--- a/src/utils/calls.ts
+++ b/src/utils/calls.ts
@@ -12,7 +12,7 @@ export async function callDetailPage(packageName: string, packageVersion?: strin
   return packageMeta;
 }
 
-export function callSearch(value: string, signal: any) {
+export function callSearch(value: string, signal: AbortSignal) {
   // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#Browser_compatibility
   // FUTURE: signal is not well supported for IE and Samsung Browser
   return API.request(`search/${encodeURIComponent(value)}`, 'GET', { signal, headers: {} });


### PR DESCRIPTION
This PR removes some `ts-ignore` instructions that where placed around the`API` class.

No actual code changes, just more streamlined typings, even though I would like to rewrite the API class with async/await syntax later. But since there is nothing wrong with the actual promised based code I didn't for this PR.