### PR TITLE
Fix: fixed tests errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [["@verdaccio"]]
+  "presets": [["@verdaccio"]],
+  "plugins": ["emotion"]
 }


### PR DESCRIPTION
**Type:** Fix

**Description:**

The tests were not passing, because  the emotion plugin was not defined in the` .babelrc`. Please see the error below: 

![image](https://user-images.githubusercontent.com/29228205/69039847-068ca080-09ed-11ea-9805-96e6ef41e406.png)

