### PR TITLE
fix: time format localization

### DIFF
--- a/src/utils/package.test.ts
+++ b/src/utils/package.test.ts
@@ -50,7 +50,7 @@ describe('formatRepository', (): void => {
 describe('formatDate', (): void => {
   test('should format the date', (): void => {
     const date = 1532211072138;
-    expect(formatDate(date)).toEqual('21.07.2018, 22:11:12');
+    expect(formatDate(date)).toEqual('07/21/2018 10:11:12 PM');
   });
 });
 
@@ -78,7 +78,7 @@ describe('formatDateDistance', (): void => {
 describe('getLastUpdatedPackageTime', (): void => {
   test('should get the last update time', (): void => {
     const lastUpdated = packageMeta._uplinks;
-    expect(getLastUpdatedPackageTime(lastUpdated)).toEqual('22.07.2018, 22:11:12');
+    expect(getLastUpdatedPackageTime(lastUpdated)).toEqual('07/22/2018 10:11:12 PM');
   });
 
   test('should get the last update time for blank uplink', (): void => {
@@ -91,9 +91,9 @@ describe('getRecentReleases', (): void => {
   test('should get the recent releases', (): void => {
     const { time } = packageMeta;
     const result = [
-      { time: '14.12.2017, 15:43:27', version: '2.7.1' },
-      { time: '05.12.2017, 23:25:06', version: '2.7.0' },
-      { time: '08.11.2017, 22:47:16', version: '2.6.6' },
+      { time: '12/14/2017 3:43:27 PM', version: '2.7.1' },
+      { time: '12/05/2017 11:25:06 PM', version: '2.7.0' },
+      { time: '11/08/2017 10:47:16 PM', version: '2.6.6' },
     ];
     expect(getRecentReleases(time)).toEqual(result);
     expect(getRecentReleases()).toEqual([]);

--- a/src/utils/package.ts
+++ b/src/utils/package.ts
@@ -5,12 +5,14 @@ import { UpLinks } from '@verdaccio/types';
 import isString from 'lodash/isString';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 
 import { Time } from '../../types/packageMeta';
 
-export const TIMEFORMAT = 'DD.MM.YYYY, HH:mm:ss';
+export const TIMEFORMAT = 'L LTS';
 
 dayjs.extend(relativeTime);
+dayjs.extend(localizedFormat);
 
 /**
  * Formats license field for webui.


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type: translate**

The following has been addressed in the PR:
* fix, the time format is not localized at package list.

*  There is a related issue?
No
*  Unit or Functional tests are included in the PR
Yes, It bit fixed due to time format changed

**Description:**
Verdaccio configure `TIME FORMAT` to `DD.MM.YYYY, HH:mm:ss`, but actually the date time format is strongly depend to language.

ex(day.js localization) ...
in English: `MM/DD/YYYY HH:MM:SS A`
in French: `DD/MM/YYYY HH:MM:SS`
in German: `DD.MM.YYYY HH:MM:SS`
in Japanese: `YYYY/MM/DD HH:MM:SS`

day.js has [localized format plugin](https://day.js.org/docs/en/plugin/localized-format) which solve date time format localization problem like above.

In this PR, use it to localize date time in package list and also contains fix tests for these changes.

<!-- Resolves #??? -->
