### PR TITLE
fix: revert custom favicon (#463)

### DIFF
--- a/src/template/index.html
+++ b/src/template/index.html
@@ -6,7 +6,7 @@
     <title>
         <%= htmlWebpackPlugin.options.title %>
     </title>
-    <link rel="icon" type="image/png" href="<%= htmlWebpackPlugin.options.verdaccioURL %>/-/mapped/favicon" />
+    <link rel="icon" type="image/png" href="<%= htmlWebpackPlugin.options.verdaccioURL %>/-/static/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script>
         window.__VERDACCIO_BASENAME_UI_OPTIONS = JSON.parse('<%= htmlWebpackPlugin.options.__UI_OPTIONS %>');

--- a/tools/webpack.prod.config.babel.js
+++ b/tools/webpack.prod.config.babel.js
@@ -49,6 +49,7 @@ const prodConf = {
       logo: 'ToReplaceByLogo',
       primary_color: 'ToReplaceByPrimaryColor',
       filename: 'index.html',
+      favicon: `${env.SRC_ROOT}/template/favicon.ico`,
       verdaccioURL: 'ToReplaceByVerdaccio',
       version_app: 'ToReplaceByVersion',
       template: `${env.SRC_ROOT}/template/index.html`,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue? https://github.com/verdaccio/ui/pull/463
*  Unit or Functional tests are included in the PR

**Description:**

This reverts commit 4713dea3 to unblock deployments

Unfortunately the merge contains a bug, we need to try again

https://github.com/verdaccio/verdaccio/pull/1787#pullrequestreview-421269464

