### PR TITLE
fix: error on header color in dark mode #478

### DIFF
--- a/src/design-tokens/theme.ts
+++ b/src/design-tokens/theme.ts
@@ -34,7 +34,7 @@ const themeModes = {
   },
   dark: {
     ...colors,
-    primary: '#fff',
+    primary: '#24394e',
     secondary: '#424242',
     background: '#1A202C',
   },


### PR DESCRIPTION
-->
**Type:** bug

**Description:**

Resolves #478 - Registry Info window has wrong header style in Dark mode

I tried multiple colors, so no other components break with this change (see https://github.com/verdaccio/ui/issues/478#issuecomment-643599923).

![image](https://user-images.githubusercontent.com/3247664/84566390-e6e60c80-ad70-11ea-9fe1-233e1d9da883.png)
