### PR TITLE
Feature: Strict Typing for AutoComplete Component

### DIFF
--- a/src/components/AutoComplete/AutoComplete.tsx
+++ b/src/components/AutoComplete/AutoComplete.tsx
@@ -2,7 +2,16 @@ import styled from '@emotion/styled';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
 import React, { KeyboardEvent, memo } from 'react';
-import Autosuggest, { SuggestionSelectedEventData, InputProps, ChangeEvent, SuggestionsFetchRequested, GetSuggestionValue, RenderSuggestion, RenderSuggestionsContainer, RenderInputComponent } from 'react-autosuggest';
+import Autosuggest, {
+  SuggestionSelectedEventData,
+  InputProps,
+  ChangeEvent,
+  SuggestionsFetchRequested,
+  GetSuggestionValue,
+  RenderSuggestion,
+  RenderSuggestionsContainer,
+  RenderInputComponent,
+} from 'react-autosuggest';
 import { useTranslation } from 'react-i18next';
 
 import { Theme } from 'verdaccio-ui/design-tokens/theme';
@@ -30,7 +39,7 @@ interface Props {
   startAdornment?: JSX.Element;
   disableUnderline?: boolean;
   onChange: (event: React.FormEvent<HTMLInputElement>, params: ChangeEvent) => void;
-  onSuggestionsFetch: SuggestionsFetchRequested;//({ value: string }) => Promise<void>;
+  onSuggestionsFetch: SuggestionsFetchRequested;
   onCleanSuggestions?: () => void;
   onClick?: (event: React.FormEvent<HTMLInputElement>, data: SuggestionSelectedEventData<unknown>) => void;
   onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
@@ -41,11 +50,11 @@ interface Suggestion {
   name: string;
 }
 
-type CustomInputProps = Pick<Props, "disableUnderline" | "startAdornment">;
+type CustomInputProps = Pick<Props, 'disableUnderline' | 'startAdornment'>;
 
 /* eslint-disable react/jsx-sort-props  */
 /* eslint-disable verdaccio/jsx-spread */
-const renderInputComponent: RenderInputComponent<Suggestion> = (inputProps) => {
+const renderInputComponent: RenderInputComponent<Suggestion> = inputProps => {
   // @ts-ignore
   const { ref, startAdornment, disableUnderline, onKeyDown, ...others } = inputProps;
   return (
@@ -124,7 +133,11 @@ const AutoComplete = memo(
     };
 
     // this format avoid arrow function eslint rule
-    const renderSuggestionsContainer: RenderSuggestionsContainer = function({ containerProps, children, query }): JSX.Element {
+    const renderSuggestionsContainer: RenderSuggestionsContainer = function({
+      containerProps,
+      children,
+      query,
+    }): JSX.Element {
       return (
         <SuggestionContainer {...containerProps} square={true}>
           {suggestionsLoaded && children === null && query && renderMessage(t('autoComplete.no-results-found'))}
@@ -133,7 +146,7 @@ const AutoComplete = memo(
           {children}
         </SuggestionContainer>
       );
-    }
+    };
 
     return (
       <Wrapper>

--- a/src/components/AutoComplete/styles.tsx
+++ b/src/components/AutoComplete/styles.tsx
@@ -37,7 +37,7 @@ export const StyledTextField = styled(TextField)<{ theme?: Theme }>(props => ({
 
 /* eslint-disable verdaccio/jsx-spread */
 // @ts-ignore types of color are incompatible
-export const InputField: React.FC<InputFieldProps> = ({ ...others }) => <StyledTextField {...others} />;
+export const InputField: React.FC<InputFieldProps & TextFieldProps> = ({ ...others }) => <StyledTextField {...others} />;
 
 export const SuggestionContainer = styled(Paper)({
   maxHeight: '500px',

--- a/src/components/AutoComplete/styles.tsx
+++ b/src/components/AutoComplete/styles.tsx
@@ -37,7 +37,9 @@ export const StyledTextField = styled(TextField)<{ theme?: Theme }>(props => ({
 
 /* eslint-disable verdaccio/jsx-spread */
 // @ts-ignore types of color are incompatible
-export const InputField: React.FC<InputFieldProps & TextFieldProps> = ({ ...others }) => <StyledTextField {...others} />;
+export const InputField: React.FC<InputFieldProps & TextFieldProps> = ({ ...others }) => (
+  <StyledTextField {...others} />
+);
 
 export const SuggestionContainer = styled(Paper)({
   maxHeight: '500px',


### PR DESCRIPTION
This PR makes `AutoComplete.tsx` compatible with TypeScripts `strict` mode.
Unfortunately I had to introduce a `@ts-ignore` directive in 1 place since the provided `RenderInputComponent<T>` type does not allow to specify custom input props which we make use of. See here: https://github.com/moroshko/react-autosuggest#input-props-prop

The first generic in `RenderInputComponent<T>` only models the Suggestion, so there is currently no way to type custom input props. Ideally in the future it will allow a 2nd generic that allows you to model them like `RenderInputComponent<Suggestion, CustomInputProps>`.
I already specified the custom input prop that would need to be used: `type CustomInputProps = Pick<Props, 'disableUnderline' | 'startAdornment'>;`
So once this is fixed we can remove the tsignore again and fill in the 2nd generic and this should be it.