### PR TITLE
Refactor: Enabled typescript strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "stylelint-webpack-plugin": "1.1.2",
     "supertest": "4.0.2",
     "typeface-roboto": "0.0.75",
-    "typescript": "3.9.5",
+    "typescript": "3.9.6",
     "uglifyjs-webpack-plugin": "2.2.0",
     "url-loader": "3.0.0",
     "validator": "12.1.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
   "scripts": {
     "type-check": "tsc --noEmit --pretty",
     "type-check:watch": "npm run type-check -- --watch",
-    "type-check-strict:watch": "tsc --project ./tsconfig.strict.json --noEmit --pretty --watch",
     "release": "standard-version -a",
     "test:clean": "npx jest --clearCache",
     "test:acceptance": "codeceptjs run --steps",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "stylelint-webpack-plugin": "1.1.2",
     "supertest": "4.0.2",
     "typeface-roboto": "0.0.75",
-    "typescript": "3.7.4",
+    "typescript": "3.9.5",
     "uglifyjs-webpack-plugin": "2.2.0",
     "url-loader": "3.0.0",
     "validator": "12.1.0",

--- a/src/App/Header/Header.tsx
+++ b/src/App/Header/Header.tsx
@@ -22,9 +22,9 @@ interface Props {
 const Header: React.FC<Props> = ({ withoutSearch }) => {
   const { t } = useTranslation();
   const appContext = useContext(AppContext);
-  const [isInfoDialogOpen, setOpenInfoDialog] = useState();
-  const [showMobileNavBar, setShowMobileNavBar] = useState();
-  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [isInfoDialogOpen, setOpenInfoDialog] = useState<boolean>(false);
+  const [showMobileNavBar, setShowMobileNavBar] = useState<boolean>(false);
+  const [showLoginModal, setShowLoginModal] = useState<boolean>(false);
 
   if (!appContext) {
     throw Error(t('app-context-not-correct-used'));

--- a/src/App/Header/HeaderRight.tsx
+++ b/src/App/Header/HeaderRight.tsx
@@ -27,8 +27,8 @@ const HeaderRight: React.FC<Props> = ({
   onOpenRegistryInfoDialog,
 }) => {
   const themeContext = useContext(ThemeContext);
-  const [anchorEl, setAnchorEl] = useState();
-  const [isMenuOpen, setIsMenuOpen] = useState();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
 
   const { t } = useTranslation();
 

--- a/src/App/Header/LoginDialog/LoginDialog.tsx
+++ b/src/App/Header/LoginDialog/LoginDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import Dialog from 'verdaccio-ui/components/Dialog';
 import DialogContent from 'verdaccio-ui/components/DialogContent';
-import { makeLogin } from 'verdaccio-ui/utils/login';
+import { makeLogin, LoginError } from 'verdaccio-ui/utils/login';
 import storage from 'verdaccio-ui/utils/storage';
 
 import AppContext from '../../../App/AppContext';
@@ -25,7 +25,7 @@ const LoginDialog: React.FC<Props> = ({ onClose, open = false }) => {
     throw Error(t('app-context-not-correct-used'));
   }
 
-  const [error, setError] = useState();
+  const [error, setError] = useState<LoginError>();
 
   const handleDoLogin = useCallback(
     async (data: FormValues) => {

--- a/src/pages/Version/VersionContextProvider.tsx
+++ b/src/pages/Version/VersionContextProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { PackageMetaInterface } from 'types/packageMeta';
 
 import { callDetailPage, callReadme } from 'verdaccio-ui/utils/calls';
 
@@ -17,10 +18,10 @@ const VersionContextProvider: React.FC = ({ children }) => {
   const { version, package: pkgName, scope } = useParams<Params>();
   const [packageName, setPackageName] = useState(getRouterPackageName(pkgName, scope));
   const [packageVersion, setPackageVersion] = useState(version);
-  const [packageMeta, setPackageMeta] = useState();
-  const [readMe, setReadme] = useState();
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasNotBeenFound, setHasNotBeenFound] = useState();
+  const [packageMeta, setPackageMeta] = useState<PackageMetaInterface>();
+  const [readMe, setReadme] = useState<string>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [hasNotBeenFound, setHasNotBeenFound] = useState<boolean>();
 
   useEffect(() => {
     const updatedPackageName = getRouterPackageName(pkgName, scope);

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -3,16 +3,18 @@ import api, { handleResponseType } from '../../src/utils/api';
 describe('api', () => {
   describe('handleResponseType', () => {
     test('should handle missing Content-Type', async () => {
+      const responseText = `responseText`;
+      const ok = false;
       const response: Response = {
         url: 'http://localhost:8080/-/packages',
-        ok: false,
+        ok: ok,
         headers: new Headers(),
+        text: async () => responseText,
       } as Response;
 
       const handled = await handleResponseType(response);
 
-      // Should this actually return [false, null] ?
-      expect(handled).toBeUndefined();
+      expect(handled).toEqual([ok, responseText]);
     });
 
     test('should test tgz scenario', async () => {
@@ -94,9 +96,9 @@ describe('api', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith('https://verdaccio.tld/resource', {
         credentials: 'same-origin',
-        headers: {
+        headers: new Headers({
           Authorization: 'Bearer token-xx-xx-xx',
-        },
+        }),
         method: 'GET',
       });
       expect(response).toEqual({ c: 3 });

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -7,7 +7,7 @@ describe('api', () => {
       const ok = false;
       const response: Response = {
         url: 'http://localhost:8080/-/packages',
-        ok: ok,
+        ok,
         headers: new Headers(),
         text: async () => responseText,
       } as Response;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,7 +6,7 @@ import '../../types';
  * @param {object} response
  * @returns {promise}
  */
-export function handleResponseType(response: Response): Promise<[boolean, Blob | string] | void> {
+export function handleResponseType(response: Response): Promise<[boolean, any]> {
   if (response.headers) {
     const contentType = response.headers.get('Content-Type');
     if (contentType && contentType.includes('application/pdf')) {
@@ -26,7 +26,7 @@ export function handleResponseType(response: Response): Promise<[boolean, Blob |
     }
   }
 
-  return Promise.resolve();
+  return Promise.all([response.ok, response.text()]);
 }
 
 class API {
@@ -36,10 +36,11 @@ class API {
     }
 
     const token = storage.getItem('token');
-    if (token && options.headers && typeof options.headers['Authorization'] === 'undefined') {
-      options.headers = Object.assign({}, options.headers, {
-        ['Authorization']: `Bearer ${token}`,
-      });
+    const headers = new Headers(options.headers);
+
+    if (token && headers.has('Authorization') === false) {
+      headers.set('Authorization', `Bearer ${token}`);
+      options.headers = headers;
     }
 
     if (!['http://', 'https://', '//'].some(prefix => url.startsWith(prefix))) {

--- a/src/utils/calls.ts
+++ b/src/utils/calls.ts
@@ -2,15 +2,15 @@ import { PackageMetaInterface } from '../../types/packageMeta';
 
 import API from './api';
 
-export async function callReadme(packageName: string, packageVersion?: string): Promise<string | {}> {
-  return await API.request<string | {}>(
+export async function callReadme(packageName: string, packageVersion?: string): Promise<string> {
+  return await API.request<string>(
     `package/readme/${packageName}${packageVersion ? `?v=${packageVersion}` : ''}`,
     'GET'
   );
 }
 
-export async function callDetailPage(packageName: string, packageVersion?: string): Promise<PackageMetaInterface | {}> {
-  const packageMeta = await API.request<PackageMetaInterface | {}>(
+export async function callDetailPage(packageName: string, packageVersion?: string): Promise<PackageMetaInterface> {
+  const packageMeta = await API.request<PackageMetaInterface>(
     `sidebar/${packageName}${packageVersion ? `?v=${packageVersion}` : ''}`,
     'GET'
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "esnext",
     "module": "commonjs",
     "moduleResolution": "node",
-    "noImplicitAny": false,
     "strict": true,
     "outDir": "build",
     "allowSyntheticDefaultImports": true,

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "noImplicitAny": true
-    }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14803,10 +14803,10 @@ typeface-roboto@0.0.75:
   resolved "https://registry.verdaccio.org/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
   integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
-typescript@3.7.4:
-  version "3.7.4"
-  resolved "https://registry.verdaccio.org/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@3.9.5:
+  version "3.9.5"
+  resolved "https://registry.verdaccio.org/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uglify-js@3.4.x:
   version "3.4.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14803,10 +14803,10 @@ typeface-roboto@0.0.75:
   resolved "https://registry.verdaccio.org/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
   integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
-typescript@3.9.5:
-  version "3.9.5"
-  resolved "https://registry.verdaccio.org/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
This PR removes the `"noImplicitAny": false` option from `tsconfig.json`.
Meaning the source code is now compatible with the Typescript `strict` setting, providing the highest type safety. 🎉 

To enable this I had to slightly adapt the ajax code, since it wasn't possible to type the existing code without introducing too many changes.
`API.request` can return a string, json or a blob based on the response content type or url ending or void if those checks don't match.
This proved to be a quite difficult scenario to type, so as to avoid too many changes to the existing code, `API.request` now returns a string (the response bodys string) where it would have previously returned `undefined`. This allowed for only minimal changes to the existing ajax code.

However the type safety in this part is not as good as it could be. e.g:
```typescript
const response: LoginBody = await API.request('login', ...);
```
While the code expects a `LoginBody`, at runtime it could return a Blob since as said the actual return type depends on the responses content type or url ending.
It might make sense to provide separate ajax functions for when to expect string, json or Blob like:
```typescript
const response: LoginBody = await API.requestJson('login', ...);
```
This way `API.requestJson` could throw when it can't return a valid json/finds a Blob. This would make the code more failsafe.
Anyway the current code nevertheless is now `strict` mode compatible.

I also removed all the temporary helper files that where added to incrementally make `strict` mode happen.

TypeScript was also updated to the (as of now) latest version: 3.9.5

tldr:

- Set `strict` mode compilation as the new default
- `API.request` now returns a `string` in cases where it would have returned `undefined` previously
- Updated Typescript from 3.7.4 to 3.9.5