### PR TITLE
feat: allow deep links on readme pages

### DIFF
--- a/src/utils/sec-utils.ts
+++ b/src/utils/sec-utils.ts
@@ -1,7 +1,15 @@
-import { filterXSS } from 'xss';
+import { filterXSS, escapeAttrValue } from 'xss';
+
+const xssOpts = {
+  onIgnoreTagAttr: function(tag: string, name: string, value: string) {
+    if (tag.match(/^h[0-9]$/) && name === 'id') {
+      return name + '="' + escapeAttrValue(value) + '"';
+    }
+  },
+};
 
 export function preventXSS(text: string): string {
-  const encodedText = filterXSS(text);
+  const encodedText = filterXSS(text, xssOpts);
 
   return encodedText;
 }


### PR DESCRIPTION
**feature**

allow deep (aka anchor,i.e. \#usage) links in the markdown of readme pages. 

The following has been addressed in the PR:

*  see https://github.com/verdaccio/verdaccio/issues/1938

**Description:**

The underlying markdown Parser already provides header ids in the generated html code for the readme files. Unfortunately these ids are filtered by the xss module. This PR adds a onIgnoreTagAttr helper for h1, h2, ..., h9 ids so that TOC navigation and direct links to paragraphs (i.e. http://localhost:4872/-/web/detail/jquery#including-jquery ) work.

