### PR TITLE
fix(ui): Fix  sidebar - developer empty section

### DIFF
--- a/src/pages/Version/DetailSidebar/Developers/Developers.tsx
+++ b/src/pages/Version/DetailSidebar/Developers/Developers.tsx
@@ -50,7 +50,7 @@ const Developers: React.FC<Props> = ({ type, visibleMax = VISIBLE_MAX }) => {
   const [visibleDevelopers, setVisibleDevelopers] = useState(developers);
 
   useEffect(() => {
-    if (!developers) return;
+    if (!developers.length) return;
     setVisibleDevelopers(developers.slice(0, visibleDevelopersMax));
   }, [developers, visibleDevelopersMax]);
 
@@ -58,7 +58,7 @@ const Developers: React.FC<Props> = ({ type, visibleMax = VISIBLE_MAX }) => {
     setVisibleDevelopersMax(visibleDevelopersMax + VISIBLE_MAX);
   }, [visibleDevelopersMax]);
 
-  if (!visibleDevelopers || !developers) return null;
+  if (!visibleDevelopers || !developers.length) return null;
 
   return (
     <>

--- a/src/pages/Version/DetailSidebar/Developers/get-unique-developer-values.ts
+++ b/src/pages/Version/DetailSidebar/Developers/get-unique-developer-values.ts
@@ -1,7 +1,7 @@
 import { Developer } from '../../../../../types/packageMeta';
 
-function getUniqueDeveloperValues(developers?: Array<Developer>): undefined | Array<Developer> {
-  if (!developers) return;
+function getUniqueDeveloperValues(developers?: Array<Developer>): Array<Developer> {
+  if (!developers) return [];
   return developers.reduce(
     (accumulator: Array<Developer>, current: Developer) =>
       accumulator.some(developer => developer.email === current.email) ? accumulator : [...accumulator, current],


### PR DESCRIPTION
**Type:** Fix

The following has been addressed in the PR: https://github.com/verdaccio/ui/issues/458

**Description:** The Sidebar Maintainers/Contributors section is displayed if it comes empty []. This PR fixes the issue.

