### PR TITLE
Remove capitalisation from greeting label

### DIFF
--- a/src/App/Header/HeaderGreetings.tsx
+++ b/src/App/Header/HeaderGreetings.tsx
@@ -14,7 +14,7 @@ const HeaderGreetings: React.FC<Props> = ({ username }) => {
   return (
     <>
       <Greetings>{t('header.greetings')}</Greetings>
-      <Label capitalize={true} data-testid="greetings-label" text={username} weight="bold" />
+      <Label data-testid="greetings-label" text={username} weight="bold" />
     </>
   );
 };

--- a/src/pages/Version/DetailContainer/UpLinks/__snapshots__/UpLinks.test.tsx.snap
+++ b/src/pages/Version/DetailContainer/UpLinks/__snapshots__/UpLinks.test.tsx.snap
@@ -128,7 +128,7 @@ Object {
             <span
               class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
             >
-              2 years ago
+              3 years ago
             </span>
           </div>
         </li>
@@ -186,7 +186,7 @@ Object {
           <span
             class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
           >
-            2 years ago
+            3 years ago
           </span>
         </div>
       </li>


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

Removing capitalisation from greeting label. When Verdaccio is welcoming a user based on their username, it is odd to capitalise the first letter, it is probably better to make zero assumptions about the formatting of the name rather than try and format it ourselves on the UI and simply accept whatever the auth source provides as a source of truth.

In the attached screenshot, you can see the strangeness I mention, "Imjacobclark" opposed to "imjacobclark".

![Screenshot 2021-01-12 at 15 28 14](https://user-images.githubusercontent.com/1641689/104334945-da828780-54ea-11eb-9732-b79893720112.png)
