### PR TITLE
feat!: reduce bundle size webpack improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,18 +179,6 @@
     {
       "path": "./static/main.*.js",
       "maxSize": "400 kB"
-    },
-    {
-      "path": "./static/*.svg",
-      "maxSize": "1.3 kB"
-    },
-    {
-      "path": "./static/*.png",
-      "maxSize": "15 kB"
-    },
-    {
-      "path": "./static/fonts/*.{woff,woff2}",
-      "maxSize": "20 kB"
     }
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "stylelint-webpack-plugin": "^2.1.1",
     "supertest": "4.0.2",
     "terser-webpack-plugin": "^5.0.3",
-    "typeface-roboto": "0.0.75",
     "typescript": "3.9.6",
     "url-loader": "^4.1.1",
     "validator": "13.1.1",

--- a/src/design-tokens/StyleBaseline.tsx
+++ b/src/design-tokens/StyleBaseline.tsx
@@ -1,7 +1,6 @@
 import CssBaseline from '@material-ui/core/CssBaseline';
 import React from 'react';
 import 'normalize.css';
-import 'typeface-roboto/index.css';
 
 import ResetCSS from './ResetStyles';
 

--- a/src/design-tokens/theme.ts
+++ b/src/design-tokens/theme.ts
@@ -84,7 +84,13 @@ export const getTheme = (themeMode: ThemeMode) => {
   const palette = themeModes[themeMode];
   return createMuiTheme({
     typography: {
-      fontFamily: 'inherit',
+      fontFamily: [
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Helvetica Neue"',
+        'Arial',
+        'sans-serif',
+      ].join(','),
     },
     palette: {
       type: themeMode,

--- a/src/design-tokens/theme.ts
+++ b/src/design-tokens/theme.ts
@@ -84,13 +84,7 @@ export const getTheme = (themeMode: ThemeMode) => {
   const palette = themeModes[themeMode];
   return createMuiTheme({
     typography: {
-      fontFamily: [
-        '-apple-system',
-        'BlinkMacSystemFont',
-        '"Helvetica Neue"',
-        'Arial',
-        'sans-serif',
-      ].join(','),
+      fontFamily: ['-apple-system', 'BlinkMacSystemFont', '"Helvetica Neue"', 'Arial', 'sans-serif'].join(','),
     },
     palette: {
       type: themeMode,

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -47,15 +47,6 @@ module.exports = {
 
   module: {
     rules: [
-      /* Pre loader */
-      {
-        enforce: 'pre',
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        use: 'eslint-loader',
-      },
-
-      /* Normal loader */
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
@@ -69,31 +60,11 @@ module.exports = {
       },
       {
         test: /\.(jpe?g|png|gif|svg)$/,
-        use: [
-          {
-            loader: 'file-loader',
-          },
-        ],
-      },
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/,
-        loader: 'url-loader',
-        options: {
-          name: '[name].[ext]',
-          outputPath: 'fonts',
-          limit: 50,
-        },
+        type: 'asset/inline',
       },
       {
         test: /\.css$/,
-        use: [
-          {
-            loader: 'style-loader',
-          },
-          {
-            loader: 'css-loader',
-          },
-        ],
+        type: 'asset/inline',
       },
       /* Typescript loader */
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,7 +3910,6 @@ __metadata:
     stylelint-webpack-plugin: ^2.1.1
     supertest: 4.0.2
     terser-webpack-plugin: ^5.0.3
-    typeface-roboto: 0.0.75
     typescript: 3.9.6
     url-loader: ^4.1.1
     validator: 13.1.1
@@ -19448,13 +19447,6 @@ resolve@~1.7.1:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: c9ef0176aaf32593514c31e5c6edc1db970847aff6e1f0a0570a6ac0cc996335792f394c2fcec59cc76691d22a01888ea073a2f3c6930cfcf7c519addf4e2ad7
-  languageName: node
-  linkType: hard
-
-"typeface-roboto@npm:0.0.75":
-  version: 0.0.75
-  resolution: "typeface-roboto@npm:0.0.75"
-  checksum: ee56f5cc5720b2c15ee851652f3584a53d56ec2d1448dc757e0097808071f4d7d6843e66e343483a92e94d7b3f3a9436153517818834a367977bea888fc6d429
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** build
**Description:**

Many issues reported using `prefix_url`  https://verdaccio.org/docs/en/configuration#url-prefix are related the big amount of assets to be loaded. This remove the `url()` from CSS files (or CSS at all) so we don't need to worry about that anymore. This is the first required step to solve that issue. 

Also uses new webpack 5 asset loader which comes built in. 

Reduce verdaccio size in few hundred kb. 

```
static
├── 238.35e8de97062729a5ca05.js
├── 238.35e8de97062729a5ca05.js.LICENSE.txt
├── 818.35e8de97062729a5ca05.js
├── 818.35e8de97062729a5ca05.js.LICENSE.txt
├── Dependencies.35e8de97062729a5ca05.js
├── Dependencies.35e8de97062729a5ca05.js.LICENSE.txt
├── Dist.35e8de97062729a5ca05.js
├── Dist.35e8de97062729a5ca05.js.LICENSE.txt
├── Engines.35e8de97062729a5ca05.js
├── Engines.35e8de97062729a5ca05.js.LICENSE.txt
├── favicon.ico
├── Home.35e8de97062729a5ca05.js
├── Home.35e8de97062729a5ca05.js.LICENSE.txt
├── index.html
├── Install.35e8de97062729a5ca05.js
├── Install.35e8de97062729a5ca05.js.LICENSE.txt
├── main.35e8de97062729a5ca05.js
├── main.35e8de97062729a5ca05.js.LICENSE.txt
├── NotFound.35e8de97062729a5ca05.js
├── NotFound.35e8de97062729a5ca05.js.LICENSE.txt
├── Provider.35e8de97062729a5ca05.js
├── Provider.35e8de97062729a5ca05.js.LICENSE.txt
├── Repository.35e8de97062729a5ca05.js
├── Repository.35e8de97062729a5ca05.js.LICENSE.txt
├── runtime.35e8de97062729a5ca05.js
├── runtime.35e8de97062729a5ca05.js.LICENSE.txt
├── UpLinks.35e8de97062729a5ca05.js
├── UpLinks.35e8de97062729a5ca05.js.LICENSE.txt
├── vendors.35e8de97062729a5ca05.js
├── vendors.35e8de97062729a5ca05.js.LICENSE.txt
├── Version.35e8de97062729a5ca05.js
├── Version.35e8de97062729a5ca05.js.LICENSE.txt
├── Versions.35e8de97062729a5ca05.js
└── Versions.35e8de97062729a5ca05.js.LICENSE.txt
```

#### Related tickets

https://github.com/verdaccio/verdaccio/issues/1523
https://github.com/verdaccio/verdaccio/issues/1297
https://github.com/verdaccio/verdaccio/issues/1593
https://github.com/verdaccio/verdaccio/discussions/1539
https://github.com/verdaccio/website/issues/264
https://github.com/verdaccio/verdaccio/issues/1565
https://github.com/verdaccio/verdaccio/issues/1251
https://github.com/verdaccio/verdaccio/issues/2029
https://github.com/verdaccio/docker-examples/issues/29