### PR TITLE
build: visual snapshots only on pull request

### DIFF
--- a/.github/workflows/visual-snapshots.yml
+++ b/.github/workflows/visual-snapshots.yml
@@ -1,6 +1,5 @@
 name: Visual Snapshots
 on:
-  push:
   pull_request:
     paths:
       - .github/workflows/visual-snapshots.yml


### PR DESCRIPTION
Small improvement, it will run visual snapshots only on pull request.

We should not run external services on master that might force a release failure, furthermore we don't work on master only via pull request, thus so it won't have much impact. 