### PR TITLE
feat: replace base path

### DIFF
--- a/tools/webpack.prod.config.babel.js
+++ b/tools/webpack.prod.config.babel.js
@@ -46,7 +46,7 @@ const prodConf = {
     }),
     new HTMLWebpackPlugin({
       title: 'ToReplaceByTitle',
-      basePath: 'ToReplaceByVerdaccio',
+      basePath: 'ToReplaceByVerdaccioBase',
       faviIcoPath: `ToReplaceByVerdaccioFavico`,
       __UI_OPTIONS: 'ToReplaceByVerdaccioUI',
       filename: 'index.html',


### PR DESCRIPTION
Again regarding https://github.com/verdaccio/verdaccio/pull/2122

By using `ToReplaceByVerdaccio` also replaces `ToReplaceByVerdaccioFavico`, so  must be renamed.

```
 basePath: 'ToReplaceByVerdaccio',
 faviIcoPath: `ToReplaceByVerdaccioFavico`,
```

This will break all E2E but there is no other way, this is one of the reason why I want to move UI to core, I cannot do breaking changes. I need to merge this even if break the test, there is no other way.